### PR TITLE
Update __init__.py

### DIFF
--- a/winapps/__init__.py
+++ b/winapps/__init__.py
@@ -103,7 +103,7 @@ _REGISTRY_KEY_TO_APPLICATION_FIELD_DICT: Mapping[str, Optional[Callable]] = defa
     'DisplayName': lambda value: ('name', _none_on_value_not_set(value)),
     'DisplayVersion': lambda value: ('version', _none_on_value_not_set(str(value))),
     'InstallDate': lambda value: (
-        'install_date', _none_on_value_not_set(value) and datetime.strptime(value, '%Y%m%d').date()),
+        'install_date', _none_on_value_not_set(value)),
     'InstallLocation': lambda value: ('install_location', _none_on_value_not_set(value) and Path(value)),
     'InstallSource': lambda value: ('install_source', _none_on_value_not_set(value) and Path(value)),
     'ModifyPath': lambda value: ('modify_path', _none_on_value_not_set(value)),


### PR DESCRIPTION
I was able to circumvent the date format error by getting rid of the check of the date "and datetime.strptime(value, '%Y%m%d').date())" from line 106 in the _init_.py. This is a dirty fix because I'm not sure what else is using this check.