### PR TITLE
Fix possible str > int comparison error

### DIFF
--- a/winapps/__init__.py
+++ b/winapps/__init__.py
@@ -171,9 +171,9 @@ def _installed_application(application_key: str) -> Optional[InstalledApplicatio
             except FileNotFoundError:
                 return False
 
-        is_system_component = name == 'SystemComponent' and value > 0
+        is_system_component = name == 'SystemComponent' and int(value or 0) > 0
         is_win_installer_absent_in_products = False
-        if name == 'WindowsInstaller' and value > 0:
+        if name == 'WindowsInstaller' and int(value or 0) > 0:
             squid = guid_to_squid(application_key.rpartition('\\')[2])
             products_key = r'Software\Classes\Installer\Products' + '\\' + squid
             if not key_exists(_ROOT_KEY, products_key):


### PR DESCRIPTION
Workaround to solve the str > int comparison in `skip()` function when _**SystemComponent key** value_ is _None_.
The same strategy was applyed in the _**WindowsInstaller key** value_ check.

The error I was encountering was:

```console
Traceback (most recent call last):
  File "C:\Users\Vinicius\dev\projects\it_asset_manager\software_info.py", line 3, in <module>
    installed_apps = [app for app in winapps.list_installed()]
  File "C:\Users\Vinicius\dev\projects\it_asset_manager\software_info.py", line 3, in <listcomp>
    installed_apps = [app for app in winapps.list_installed()]
    return (
  File "C:\Users\Vinicius\dev\projects\it_asset_manager\.venv\lib\site-packages\winapps\__init__.py", line 50, in <genexpr>
    _installed_application(application_key)
  File "C:\Users\Vinicius\dev\projects\it_asset_manager\.venv\lib\site-packages\winapps\__init__.py", line 235, in _installed_application
    if skip():
  File "C:\Users\Vinicius\dev\projects\it_asset_manager\.venv\lib\site-packages\winapps\__init__.py", line 211, in skip
    is_system_component = name == "SystemComponent" and value > 0
TypeError: '>' not supported between instances of 'str' and 'int'
```